### PR TITLE
Refactor command creation to ViewModel

### DIFF
--- a/src/main/java/cose457/drawingtool/view/MainWindowView.java
+++ b/src/main/java/cose457/drawingtool/view/MainWindowView.java
@@ -1,8 +1,5 @@
 package cose457.drawingtool.view;
 
-import cose457.drawingtool.command.AddShapeCommand;
-import cose457.drawingtool.factory.ShapeModelFactory;
-import cose457.drawingtool.model.ShapeModel;
 import cose457.drawingtool.model.ShapeType;
 import cose457.drawingtool.util.ShapeRenderer;
 import cose457.drawingtool.viewmodel.CanvasViewModel;
@@ -87,26 +84,8 @@ public class MainWindowView {
             double width = Math.abs(endX - startX);
             double height = Math.abs(endY - startY);
 
-            // 도형 타입에 따라 Model 생성
-            ShapeType type = getSelectedShapeType(); // ComboBox 등에서 선택된 값
-            ShapeModel model;
-            switch (type) {
-                case RECTANGLE:
-                    model = ShapeModelFactory.rectangle()
-                            .x(x).y(y).width(width).height(height).zOrder(0).build();
-                    break;
-                case ELLIPSE:
-                    model = ShapeModelFactory.ellipse()
-                            .x(x).y(y).width(width).height(height).zOrder(0).build();
-                    break;
-                // 기타 도형 생략
-                default:
-                    return;
-            }
-
-            // Command 생성 및 실행
-            AddShapeCommand command = new AddShapeCommand(canvasViewModel.getCanvasModel(), model);
-            canvasViewModel.executeCommand(command);
+            ShapeType type = getSelectedShapeType();
+            canvasViewModel.addShape(type, x, y, width, height);
         });
 
         canvasViewModel.addListener(this::redrawCanvas);

--- a/src/main/java/cose457/drawingtool/viewmodel/CanvasViewModel.java
+++ b/src/main/java/cose457/drawingtool/viewmodel/CanvasViewModel.java
@@ -1,14 +1,15 @@
 package cose457.drawingtool.viewmodel;
 
+import cose457.drawingtool.command.AddShapeCommand;
 import cose457.drawingtool.command.Command;
+import cose457.drawingtool.factory.ShapeModelFactory;
 import cose457.drawingtool.factory.ShapeViewModelFactory;
 import cose457.drawingtool.model.CanvasModel;
 import cose457.drawingtool.model.ShapeModel;
+import cose457.drawingtool.model.ShapeType;
 import cose457.drawingtool.util.Observable;
-import cose457.drawingtool.util.ObservableList;
 import lombok.Getter;
 
-import java.sql.Array;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -26,7 +27,7 @@ public class CanvasViewModel implements Observable<List<ShapeViewModel>> {
     private final Deque<Command> undoStack = new ArrayDeque<>();
     private final Deque<Command> redoStack = new ArrayDeque<>();
 
-    ShapeViewModelFactory shapeViewModelFactory = new ShapeViewModelFactory();
+    private final ShapeViewModelFactory shapeViewModelFactory = new ShapeViewModelFactory();
 
     public CanvasViewModel() {
         canvasModel.addListener(shapeModels -> {
@@ -56,6 +57,33 @@ public class CanvasViewModel implements Observable<List<ShapeViewModel>> {
             cmd.execute();
             undoStack.push(cmd);
         }
+    }
+
+    /**
+     * Create a shape model based on user parameters and add it to the canvas
+     * through a command. The view only needs to provide the primitive data
+     * required to create the shape.
+     */
+    public void addShape(ShapeType type, double x, double y, double width, double height) {
+        ShapeModel model;
+        switch (type) {
+            case RECTANGLE -> model = ShapeModelFactory.rectangle()
+                    .x(x).y(y).width(width).height(height).zOrder(0).build();
+            case ELLIPSE -> model = ShapeModelFactory.ellipse()
+                    .x(x).y(y).width(width).height(height).zOrder(0).build();
+            case LINE -> model = ShapeModelFactory.line()
+                    .x(x).y(y).width(width).height(height).zOrder(0).build();
+            case TEXT -> model = ShapeModelFactory.text()
+                    .x(x).y(y).width(width).height(height).zOrder(0).build();
+            case IMAGE -> model = ShapeModelFactory.image()
+                    .x(x).y(y).width(width).height(height).zOrder(0).build();
+            default -> {
+                return;
+            }
+        }
+
+        AddShapeCommand command = new AddShapeCommand(canvasModel, model);
+        executeCommand(command);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- avoid creating commands in the view
- let `CanvasViewModel` build shapes and commands via `addShape`
- adjust `MainWindowView` to pass primitive values only

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68428d8a339c832c897322e13178c7ac