### PR TITLE
Fix line selection bounding box

### DIFF
--- a/src/main/java/cose457/drawingtool/command/SelectShapesInAreaCommand.java
+++ b/src/main/java/cose457/drawingtool/command/SelectShapesInAreaCommand.java
@@ -40,7 +40,13 @@ public class SelectShapesInAreaCommand implements Command {
             double vy = vm.getY();
             double vw = vm.getWidth();
             double vh = vm.getHeight();
-            if (vx >= x && vy >= y && (vx + vw) <= x2 && (vy + vh) <= y2) {
+
+            double sx1 = Math.min(vx, vx + vw);
+            double sy1 = Math.min(vy, vy + vh);
+            double sx2 = Math.max(vx, vx + vw);
+            double sy2 = Math.max(vy, vy + vh);
+
+            if (sx1 >= x && sy1 >= y && sx2 <= x2 && sy2 <= y2) {
                 vm.setSelected(true);
             }
         }

--- a/src/main/java/cose457/drawingtool/viewmodel/CanvasViewModel.java
+++ b/src/main/java/cose457/drawingtool/viewmodel/CanvasViewModel.java
@@ -102,7 +102,12 @@ public class CanvasViewModel implements Observable<List<ShapeViewModel>> {
         double vw = vm.getWidth();
         double vh = vm.getHeight();
 
-        return px >= vx && px <= vx + vw && py >= vy && py <= vy + vh;
+        double x1 = Math.min(vx, vx + vw);
+        double y1 = Math.min(vy, vy + vh);
+        double x2 = Math.max(vx, vx + vw);
+        double y2 = Math.max(vy, vy + vh);
+
+        return px >= x1 && px <= x2 && py >= y1 && py <= y2;
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure shapes with negative width/height are selectable
- correct selection logic for area selection to handle lines

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842a454f4d8832cb2797882d69af7dd