### PR TITLE
Implement z-order manipulation commands

### DIFF
--- a/src/main/java/cose457/drawingtool/command/ChangeZOrderCommand.java
+++ b/src/main/java/cose457/drawingtool/command/ChangeZOrderCommand.java
@@ -1,0 +1,45 @@
+package cose457.drawingtool.command;
+
+import cose457.drawingtool.model.CanvasModel;
+import cose457.drawingtool.model.ShapeModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChangeZOrderCommand implements Command {
+    public enum Type {
+        BRING_TO_FRONT,
+        SEND_TO_BACK,
+        BRING_FORWARD,
+        SEND_BACKWARD
+    }
+
+    private final CanvasModel canvasModel;
+    private final List<ShapeModel> targets;
+    private final Type type;
+    private List<ShapeModel> previousOrder;
+
+    public ChangeZOrderCommand(CanvasModel canvasModel, List<ShapeModel> targets, Type type) {
+        this.canvasModel = canvasModel;
+        this.targets = targets;
+        this.type = type;
+    }
+
+    @Override
+    public void execute() {
+        previousOrder = new ArrayList<>(canvasModel.get());
+        switch (type) {
+            case BRING_TO_FRONT -> canvasModel.bringToFront(targets);
+            case SEND_TO_BACK -> canvasModel.sendToBack(targets);
+            case BRING_FORWARD -> canvasModel.bringForward(targets);
+            case SEND_BACKWARD -> canvasModel.sendBackward(targets);
+        }
+    }
+
+    @Override
+    public void undo() {
+        if (previousOrder != null) {
+            canvasModel.set(previousOrder);
+        }
+    }
+}

--- a/src/main/java/cose457/drawingtool/model/CanvasModel.java
+++ b/src/main/java/cose457/drawingtool/model/CanvasModel.java
@@ -34,6 +34,61 @@ public class CanvasModel implements Observable<List<ShapeModel>> {
         notifyListeners();
     }
 
+    /** Update the zOrder field of all shapes based on their index */
+    private void updateZOrders() {
+        for (int i = 0; i < shapes.size(); i++) {
+            shapes.get(i).setZOrder(i);
+        }
+    }
+
+    public void bringToFront(List<ShapeModel> targets) {
+        List<ShapeModel> ordered = shapes.stream()
+                .filter(targets::contains)
+                .toList();
+        shapes.removeAll(ordered);
+        shapes.addAll(ordered);
+        updateZOrders();
+        notifyListeners();
+    }
+
+    public void sendToBack(List<ShapeModel> targets) {
+        List<ShapeModel> ordered = shapes.stream()
+                .filter(targets::contains)
+                .toList();
+        shapes.removeAll(ordered);
+        shapes.addAll(0, ordered);
+        updateZOrders();
+        notifyListeners();
+    }
+
+    public void bringForward(List<ShapeModel> targets) {
+        for (int i = shapes.size() - 2; i >= 0; i--) {
+            ShapeModel current = shapes.get(i);
+            if (targets.contains(current)) {
+                ShapeModel next = shapes.get(i + 1);
+                if (!targets.contains(next)) {
+                    Collections.swap(shapes, i, i + 1);
+                }
+            }
+        }
+        updateZOrders();
+        notifyListeners();
+    }
+
+    public void sendBackward(List<ShapeModel> targets) {
+        for (int i = 1; i < shapes.size(); i++) {
+            ShapeModel current = shapes.get(i);
+            if (targets.contains(current)) {
+                ShapeModel prev = shapes.get(i - 1);
+                if (!targets.contains(prev)) {
+                    Collections.swap(shapes, i, i - 1);
+                }
+            }
+        }
+        updateZOrders();
+        notifyListeners();
+    }
+
     @Override
     public void addListener(Consumer<List<ShapeModel>> listener) {
         listeners.add(listener);

--- a/src/main/java/cose457/drawingtool/view/MainWindowView.java
+++ b/src/main/java/cose457/drawingtool/view/MainWindowView.java
@@ -57,6 +57,11 @@ public class MainWindowView {
             btnSelect.setSelected(false);
         });
 
+        btnBringToFront.setOnAction(e -> canvasViewModel.bringSelectedToFront());
+        btnSendToBack.setOnAction(e -> canvasViewModel.sendSelectedToBack());
+        btnBringForward.setOnAction(e -> canvasViewModel.bringSelectedForward());
+        btnSendBackward.setOnAction(e -> canvasViewModel.sendSelectedBackward());
+
         drawCanvas.setOnMousePressed(e -> {
             startX = e.getX();
             startY = e.getY();

--- a/src/main/java/cose457/drawingtool/viewmodel/CanvasViewModel.java
+++ b/src/main/java/cose457/drawingtool/viewmodel/CanvasViewModel.java
@@ -5,6 +5,7 @@ import cose457.drawingtool.command.Command;
 import cose457.drawingtool.command.SelectShapeCommand;
 import cose457.drawingtool.command.MoveSelectedShapesCommand;
 import cose457.drawingtool.command.SelectShapesInAreaCommand;
+import cose457.drawingtool.command.ChangeZOrderCommand;
 import cose457.drawingtool.factory.ShapeModelFactory;
 import cose457.drawingtool.factory.ShapeViewModelFactory;
 import cose457.drawingtool.model.CanvasModel;
@@ -73,8 +74,35 @@ public class CanvasViewModel implements Observable<List<ShapeViewModel>> {
                 .anyMatch(vm -> vm.isSelected() && contains(vm, x, y));
     }
 
+    private List<ShapeModel> getSelectedModels() {
+        return shapeViewModels.stream()
+                .filter(ShapeViewModel::isSelected)
+                .map(ShapeViewModel::getModel)
+                .toList();
+    }
+
     public void moveSelectedShapes(double dx, double dy) {
         Command command = new MoveSelectedShapesCommand(this, dx, dy);
+        executeCommand(command);
+    }
+
+    public void bringSelectedToFront() {
+        Command command = new ChangeZOrderCommand(canvasModel, getSelectedModels(), ChangeZOrderCommand.Type.BRING_TO_FRONT);
+        executeCommand(command);
+    }
+
+    public void sendSelectedToBack() {
+        Command command = new ChangeZOrderCommand(canvasModel, getSelectedModels(), ChangeZOrderCommand.Type.SEND_TO_BACK);
+        executeCommand(command);
+    }
+
+    public void bringSelectedForward() {
+        Command command = new ChangeZOrderCommand(canvasModel, getSelectedModels(), ChangeZOrderCommand.Type.BRING_FORWARD);
+        executeCommand(command);
+    }
+
+    public void sendSelectedBackward() {
+        Command command = new ChangeZOrderCommand(canvasModel, getSelectedModels(), ChangeZOrderCommand.Type.SEND_BACKWARD);
         executeCommand(command);
     }
 


### PR DESCRIPTION
## Summary
- implement z-order modification in CanvasModel
- add ChangeZOrderCommand and new CanvasViewModel API
- connect z-order buttons in MainWindowView
- fix z-order move algorithm

## Testing
- `bash mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842a7e6ea18832c9bb131f87919fd09