### PR TITLE
Set font and default combo box item

### DIFF
--- a/src/main/java/cose457/drawingtool/HelloApplication.java
+++ b/src/main/java/cose457/drawingtool/HelloApplication.java
@@ -12,6 +12,7 @@ public class HelloApplication extends Application {
     public void start(Stage stage) throws IOException {
         FXMLLoader loader = new FXMLLoader(HelloApplication.class.getResource("view/MainWindow.fxml"));
         Scene scene = new Scene(loader.load());
+        scene.getStylesheets().add(HelloApplication.class.getResource("style.css").toExternalForm());
         stage.setTitle("Vector Drawing Tool");
         stage.setScene(scene);
         stage.show();

--- a/src/main/java/cose457/drawingtool/view/MainWindowView.java
+++ b/src/main/java/cose457/drawingtool/view/MainWindowView.java
@@ -56,6 +56,8 @@ public class MainWindowView {
         propertyPanel.setSpacing(8);
         propertyPanel.setStyle("-fx-padding:10;-fx-border-color:#cccccc;-fx-background-color:#f8f8f8;");
 
+        shapeTypeComboBox.getSelectionModel().select("Rectangle");
+
         btnSelect.selectedProperty().addListener((obs, o, n) -> {
             isDragging = false;
             isSelecting = false;

--- a/src/main/resources/cose457/drawingtool/style.css
+++ b/src/main/resources/cose457/drawingtool/style.css
@@ -1,0 +1,4 @@
+.root {
+    -fx-font-family: "Arial";
+}
+


### PR DESCRIPTION
## Summary
- apply `style.css` to use a clean default font
- set shapeTypeComboBox to select `Rectangle` when the application starts

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842bde697b8832ca815d065a1669b49