### PR TITLE
Add command for editing shape fill color

### DIFF
--- a/src/main/java/cose457/drawingtool/command/SetSelectedShapesFillColorCommand.java
+++ b/src/main/java/cose457/drawingtool/command/SetSelectedShapesFillColorCommand.java
@@ -1,0 +1,47 @@
+package cose457.drawingtool.command;
+
+import cose457.drawingtool.viewmodel.CanvasViewModel;
+import cose457.drawingtool.viewmodel.ShapeViewModel;
+import cose457.drawingtool.model.ShapeModel;
+import javafx.scene.paint.Color;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Command for changing the fill color of currently selected shapes.
+ */
+public class SetSelectedShapesFillColorCommand implements Command {
+
+    private final CanvasViewModel canvasViewModel;
+    private final Color newColor;
+    private Map<ShapeViewModel, Color> previousColors;
+
+    public SetSelectedShapesFillColorCommand(CanvasViewModel canvasViewModel, Color newColor) {
+        this.canvasViewModel = canvasViewModel;
+        this.newColor = newColor;
+    }
+
+    @Override
+    public void execute() {
+        previousColors = new HashMap<>();
+        for (ShapeViewModel vm : canvasViewModel.getShapeViewModels()) {
+            if (vm.isSelected()) {
+                ShapeModel m = vm.getModel();
+                previousColors.put(vm, m.getFillColor());
+                m.setFillColor(newColor);
+            }
+        }
+        canvasViewModel.notifyListeners();
+    }
+
+    @Override
+    public void undo() {
+        if (previousColors == null) return;
+        for (Map.Entry<ShapeViewModel, Color> entry : previousColors.entrySet()) {
+            ShapeModel m = entry.getKey().getModel();
+            m.setFillColor(entry.getValue());
+        }
+        canvasViewModel.notifyListeners();
+    }
+}

--- a/src/main/java/cose457/drawingtool/factory/ShapeModelFactory.java
+++ b/src/main/java/cose457/drawingtool/factory/ShapeModelFactory.java
@@ -3,6 +3,7 @@ package cose457.drawingtool.factory;
 import cose457.drawingtool.model.ShapeModel;
 import cose457.drawingtool.model.ShapeType;
 import cose457.drawingtool.model.shape.*;
+import javafx.scene.paint.Color;
 
 public class ShapeModelFactory {
 
@@ -30,15 +31,17 @@ public class ShapeModelFactory {
     public static class RectangleBuilder {
         private double x, y, width, height;
         private int zOrder;
+        private Color fillColor = Color.WHITE;
 
         public RectangleBuilder x(double x) { this.x = x; return this; }
         public RectangleBuilder y(double y) { this.y = y; return this; }
         public RectangleBuilder width(double width) { this.width = width; return this; }
         public RectangleBuilder height(double height) { this.height = height; return this; }
         public RectangleBuilder zOrder(int zOrder) { this.zOrder = zOrder; return this; }
+        public RectangleBuilder fillColor(Color color) { this.fillColor = color; return this; }
 
         public RectangleShape build() {
-            return new RectangleShape(x, y, width, height, zOrder);
+            return new RectangleShape(x, y, width, height, zOrder, fillColor);
         }
     }
 
@@ -46,15 +49,17 @@ public class ShapeModelFactory {
     public static class EllipseBuilder {
         private double x, y, width, height;
         private int zOrder;
+        private Color fillColor = Color.WHITE;
 
         public EllipseBuilder x(double x) { this.x = x; return this; }
         public EllipseBuilder y(double y) { this.y = y; return this; }
         public EllipseBuilder width(double width) { this.width = width; return this; }
         public EllipseBuilder height(double height) { this.height = height; return this; }
         public EllipseBuilder zOrder(int zOrder) { this.zOrder = zOrder; return this; }
+        public EllipseBuilder fillColor(Color color) { this.fillColor = color; return this; }
 
         public EllipseShape build() {
-            return new EllipseShape(x, y, width, height, zOrder);
+            return new EllipseShape(x, y, width, height, zOrder, fillColor);
         }
     }
 
@@ -62,15 +67,17 @@ public class ShapeModelFactory {
     public static class LineBuilder {
         private double x, y, width, height;
         private int zOrder;
+        private Color fillColor = Color.BLACK;
 
         public LineBuilder x(double x) { this.x = x; return this; }
         public LineBuilder y(double y) { this.y = y; return this; }
         public LineBuilder width(double width) { this.width = width; return this; }
         public LineBuilder height(double height) { this.height = height; return this; }
         public LineBuilder zOrder(int zOrder) { this.zOrder = zOrder; return this; }
+        public LineBuilder fillColor(Color color) { this.fillColor = color; return this; }
 
         public LineShape build() {
-            return new LineShape(x, y, width, height, zOrder);
+            return new LineShape(x, y, width, height, zOrder, fillColor);
         }
     }
 
@@ -79,6 +86,7 @@ public class ShapeModelFactory {
         private double x, y, width, height;
         private int zOrder;
         private String text = "";
+        private Color fillColor = Color.BLACK;
 
         public TextBuilder x(double x) { this.x = x; return this; }
         public TextBuilder y(double y) { this.y = y; return this; }
@@ -86,9 +94,10 @@ public class ShapeModelFactory {
         public TextBuilder height(double height) { this.height = height; return this; }
         public TextBuilder zOrder(int zOrder) { this.zOrder = zOrder; return this; }
         public TextBuilder text(String text) { this.text = text; return this; }
+        public TextBuilder fillColor(Color color) { this.fillColor = color; return this; }
 
         public TextShape build() {
-            return new TextShape(x, y, width, height, zOrder, text);
+            return new TextShape(x, y, width, height, zOrder, fillColor, text);
         }
     }
 
@@ -97,6 +106,7 @@ public class ShapeModelFactory {
         private double x, y, width, height;
         private int zOrder;
         private String imagePath = "";
+        private Color fillColor = Color.TRANSPARENT;
 
         public ImageBuilder x(double x) { this.x = x; return this; }
         public ImageBuilder y(double y) { this.y = y; return this; }
@@ -104,9 +114,10 @@ public class ShapeModelFactory {
         public ImageBuilder height(double height) { this.height = height; return this; }
         public ImageBuilder zOrder(int zOrder) { this.zOrder = zOrder; return this; }
         public ImageBuilder imagePath(String path) { this.imagePath = path; return this; }
+        public ImageBuilder fillColor(Color color) { this.fillColor = color; return this; }
 
         public ImageShape build() {
-            return new ImageShape(x, y, width, height, zOrder, imagePath);
+            return new ImageShape(x, y, width, height, zOrder, fillColor, imagePath);
         }
     }
 }

--- a/src/main/java/cose457/drawingtool/model/ShapeModel.java
+++ b/src/main/java/cose457/drawingtool/model/ShapeModel.java
@@ -3,6 +3,7 @@ package cose457.drawingtool.model;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import javafx.scene.paint.Color;
 
 @AllArgsConstructor
 @Getter
@@ -11,4 +12,5 @@ public abstract class ShapeModel {
 
     protected double x, y, width, height;
     protected int zOrder;
+    protected Color fillColor;
 }

--- a/src/main/java/cose457/drawingtool/model/shape/EllipseShape.java
+++ b/src/main/java/cose457/drawingtool/model/shape/EllipseShape.java
@@ -1,10 +1,11 @@
 package cose457.drawingtool.model.shape;
 
 import cose457.drawingtool.model.ShapeModel;
+import javafx.scene.paint.Color;
 
 public class EllipseShape extends ShapeModel {
 
-    public EllipseShape(double x, double y, double width, double height, int zOrder) {
-        super(x, y, width, height, zOrder);
+    public EllipseShape(double x, double y, double width, double height, int zOrder, Color fillColor) {
+        super(x, y, width, height, zOrder, fillColor);
     }
 }

--- a/src/main/java/cose457/drawingtool/model/shape/ImageShape.java
+++ b/src/main/java/cose457/drawingtool/model/shape/ImageShape.java
@@ -3,6 +3,7 @@ package cose457.drawingtool.model.shape;
 import cose457.drawingtool.model.ShapeModel;
 import lombok.Getter;
 import lombok.Setter;
+import javafx.scene.paint.Color;
 
 @Getter
 @Setter
@@ -10,8 +11,8 @@ public class ImageShape extends ShapeModel {
 
     protected String imagePath;
 
-    public ImageShape(double x, double y, double width, double height, int zOrder, String imagePath) {
-        super(x, y, width, height, zOrder);
+    public ImageShape(double x, double y, double width, double height, int zOrder, Color fillColor, String imagePath) {
+        super(x, y, width, height, zOrder, fillColor);
         this.imagePath = imagePath;
     }
 }

--- a/src/main/java/cose457/drawingtool/model/shape/LineShape.java
+++ b/src/main/java/cose457/drawingtool/model/shape/LineShape.java
@@ -1,10 +1,11 @@
 package cose457.drawingtool.model.shape;
 
 import cose457.drawingtool.model.ShapeModel;
+import javafx.scene.paint.Color;
 
 public class LineShape extends ShapeModel {
 
-    public LineShape(double x, double y, double width, double height, int zOrder) {
-        super(x, y, width, height, zOrder);
+    public LineShape(double x, double y, double width, double height, int zOrder, Color fillColor) {
+        super(x, y, width, height, zOrder, fillColor);
     }
 }

--- a/src/main/java/cose457/drawingtool/model/shape/RectangleShape.java
+++ b/src/main/java/cose457/drawingtool/model/shape/RectangleShape.java
@@ -1,10 +1,11 @@
 package cose457.drawingtool.model.shape;
 
 import cose457.drawingtool.model.ShapeModel;
+import javafx.scene.paint.Color;
 
 public class RectangleShape extends ShapeModel {
 
-    public RectangleShape(double x, double y, double width, double height, int zOrder) {
-        super(x, y, width, height, zOrder);
+    public RectangleShape(double x, double y, double width, double height, int zOrder, Color fillColor) {
+        super(x, y, width, height, zOrder, fillColor);
     }
 }

--- a/src/main/java/cose457/drawingtool/model/shape/TextShape.java
+++ b/src/main/java/cose457/drawingtool/model/shape/TextShape.java
@@ -3,6 +3,7 @@ package cose457.drawingtool.model.shape;
 import cose457.drawingtool.model.ShapeModel;
 import lombok.Getter;
 import lombok.Setter;
+import javafx.scene.paint.Color;
 
 @Getter
 @Setter
@@ -10,8 +11,8 @@ public class TextShape extends ShapeModel {
 
     protected String text;
 
-    public TextShape(double x, double y, double width, double height, int zOrder, String text) {
-        super(x, y, width, height, zOrder);
+    public TextShape(double x, double y, double width, double height, int zOrder, Color fillColor, String text) {
+        super(x, y, width, height, zOrder, fillColor);
         this.text = text;
     }
 }

--- a/src/main/java/cose457/drawingtool/util/ShapeRenderer.java
+++ b/src/main/java/cose457/drawingtool/util/ShapeRenderer.java
@@ -45,6 +45,11 @@ public class ShapeRenderer implements ShapeViewModelVisitor {
 
     @Override
     public void visit(RectangleViewModel viewModel) {
+        gc.setFill(viewModel.getFillColor());
+        gc.fillRect(
+                viewModel.getX(), viewModel.getY(),
+                viewModel.getWidth(), viewModel.getHeight()
+        );
         gc.setStroke(Color.BLACK);
         gc.setLineWidth(2);
         gc.strokeRect(
@@ -62,6 +67,11 @@ public class ShapeRenderer implements ShapeViewModelVisitor {
 
     @Override
     public void visit(EllipseViewModel viewModel) {
+        gc.setFill(viewModel.getFillColor());
+        gc.fillOval(
+                viewModel.getX(), viewModel.getY(),
+                viewModel.getWidth(), viewModel.getHeight()
+        );
         gc.setStroke(Color.BLACK);
         gc.setLineWidth(2);
         gc.strokeOval(
@@ -79,7 +89,7 @@ public class ShapeRenderer implements ShapeViewModelVisitor {
 
     @Override
     public void visit(LineViewModel viewModel) {
-        gc.setStroke(Color.BLACK);
+        gc.setStroke(viewModel.getFillColor());
         gc.setLineWidth(2);
         gc.strokeLine(
                 viewModel.getX(), viewModel.getY(),
@@ -103,7 +113,7 @@ public class ShapeRenderer implements ShapeViewModelVisitor {
                 viewModel.getX(), viewModel.getY(),
                 viewModel.getWidth(), viewModel.getHeight()
         );
-        gc.setFill(Color.BLACK);
+        gc.setFill(viewModel.getFillColor());
         String text = viewModel.text.get();
         if (text != null) {
             gc.fillText(

--- a/src/main/java/cose457/drawingtool/view/MainWindowView.java
+++ b/src/main/java/cose457/drawingtool/view/MainWindowView.java
@@ -16,6 +16,8 @@ import javafx.scene.layout.VBox;
 import javafx.scene.layout.HBox;
 import javafx.geometry.Pos;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ColorPicker;
+import javafx.scene.paint.Color;
 
 import java.util.Arrays;
 import java.util.function.Consumer;
@@ -218,6 +220,9 @@ public class MainWindowView {
         addField("Y", bounds[1], v -> { current[1] = v; applyBounds(current); });
         addField("W", bounds[2], v -> { current[2] = v; applyBounds(current); });
         addField("H", bounds[3], v -> { current[3] = v; applyBounds(current); });
+
+        Color initialColor = selected.get(0).getFillColor();
+        addColorField(initialColor);
     }
 
     private void applyBounds(double[] b) {
@@ -243,6 +248,21 @@ public class MainWindowView {
         row.getChildren().addAll(label, field);
         propertyPanel.getChildren().add(row);
         return row;
+    }
+
+    private HBox addColorField(Color value) {
+        HBox row = new HBox(5);
+        row.setAlignment(Pos.CENTER_LEFT);
+        Label label = new Label("Color:");
+        ColorPicker picker = new ColorPicker(value);
+        picker.setOnAction(e -> applyFillColor(picker.getValue()));
+        row.getChildren().addAll(label, picker);
+        propertyPanel.getChildren().add(row);
+        return row;
+    }
+
+    private void applyFillColor(Color color) {
+        canvasViewModel.setSelectedShapesFillColor(color);
     }
 
     private double[] calculateBounds(List<ShapeViewModel> vms) {

--- a/src/main/java/cose457/drawingtool/viewmodel/CanvasViewModel.java
+++ b/src/main/java/cose457/drawingtool/viewmodel/CanvasViewModel.java
@@ -7,6 +7,7 @@ import cose457.drawingtool.command.MoveSelectedShapesCommand;
 import cose457.drawingtool.command.SelectShapesInAreaCommand;
 import cose457.drawingtool.command.ChangeZOrderCommand;
 import cose457.drawingtool.command.SetSelectedShapesBoundsCommand;
+import cose457.drawingtool.command.SetSelectedShapesFillColorCommand;
 import cose457.drawingtool.factory.ShapeModelFactory;
 import cose457.drawingtool.factory.ShapeViewModelFactory;
 import cose457.drawingtool.model.CanvasModel;
@@ -14,6 +15,7 @@ import cose457.drawingtool.model.ShapeModel;
 import cose457.drawingtool.model.ShapeType;
 import cose457.drawingtool.util.Observable;
 import lombok.Getter;
+import javafx.scene.paint.Color;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -113,6 +115,11 @@ public class CanvasViewModel implements Observable<List<ShapeViewModel>> {
         executeCommand(command);
     }
 
+    public void setSelectedShapesFillColor(Color color) {
+        Command command = new SetSelectedShapesFillColorCommand(this, color);
+        executeCommand(command);
+    }
+
     public void selectShapesInArea(double x, double y, double width, double height) {
         Command command = new SelectShapesInAreaCommand(this, x, y, width, height);
         executeCommand(command);
@@ -154,15 +161,25 @@ public class CanvasViewModel implements Observable<List<ShapeViewModel>> {
         ShapeModel model;
         switch (type) {
             case RECTANGLE -> model = ShapeModelFactory.rectangle()
-                    .x(x).y(y).width(width).height(height).zOrder(0).build();
+                    .x(x).y(y).width(width).height(height)
+                    .fillColor(Color.WHITE)
+                    .zOrder(0).build();
             case ELLIPSE -> model = ShapeModelFactory.ellipse()
-                    .x(x).y(y).width(width).height(height).zOrder(0).build();
+                    .x(x).y(y).width(width).height(height)
+                    .fillColor(Color.WHITE)
+                    .zOrder(0).build();
             case LINE -> model = ShapeModelFactory.line()
-                    .x(x).y(y).width(width).height(height).zOrder(0).build();
+                    .x(x).y(y).width(width).height(height)
+                    .fillColor(Color.BLACK)
+                    .zOrder(0).build();
             case TEXT -> model = ShapeModelFactory.text()
-                    .x(x).y(y).width(width).height(height).zOrder(0).build();
+                    .x(x).y(y).width(width).height(height)
+                    .fillColor(Color.BLACK)
+                    .zOrder(0).build();
             case IMAGE -> model = ShapeModelFactory.image()
-                    .x(x).y(y).width(width).height(height).zOrder(0).build();
+                    .x(x).y(y).width(width).height(height)
+                    .fillColor(Color.TRANSPARENT)
+                    .zOrder(0).build();
             default -> {
                 return;
             }

--- a/src/main/java/cose457/drawingtool/viewmodel/ShapeViewModel.java
+++ b/src/main/java/cose457/drawingtool/viewmodel/ShapeViewModel.java
@@ -1,10 +1,9 @@
 package cose457.drawingtool.viewmodel;
 
 import cose457.drawingtool.model.ShapeModel;
-import cose457.drawingtool.util.Observable;
-import cose457.drawingtool.util.ObservableValue;
 import cose457.drawingtool.util.ShapeViewModelVisitor;
 import lombok.Getter;
+import javafx.scene.paint.Color;
 
 public abstract class ShapeViewModel {
 
@@ -22,6 +21,7 @@ public abstract class ShapeViewModel {
     public double getWidth() { return model.getWidth(); }
     public double getHeight() { return model.getHeight(); }
     public int getZOrder() { return model.getZOrder(); }
+    public Color getFillColor() { return model.getFillColor(); }
 
     // 선택 상태 getter/setter
     public boolean isSelected() { return selected; }


### PR DESCRIPTION
## Summary
- create `SetSelectedShapesFillColorCommand` to change fill color via command pattern
- expose `setSelectedShapesFillColor` in `CanvasViewModel`
- update `ShapeViewModel` and `ShapeRenderer` to access fill color via getter
- refactor property panel to use a color picker that calls into the ViewModel

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842bcccfe84832c8e96d9588923248e