### PR TITLE
Improve drag move undo

### DIFF
--- a/src/main/java/cose457/drawingtool/command/TranslateSelectedShapesCommand.java
+++ b/src/main/java/cose457/drawingtool/command/TranslateSelectedShapesCommand.java
@@ -1,0 +1,46 @@
+package cose457.drawingtool.command;
+
+import cose457.drawingtool.viewmodel.CanvasViewModel;
+import cose457.drawingtool.viewmodel.ShapeViewModel;
+import cose457.drawingtool.model.ShapeModel;
+
+/**
+ * Command for temporarily translating selected shapes without affecting the undo stack.
+ */
+public class TranslateSelectedShapesCommand implements Command {
+    private final CanvasViewModel canvasViewModel;
+    private final double dx;
+    private final double dy;
+
+    public TranslateSelectedShapesCommand(CanvasViewModel canvasViewModel, double dx, double dy) {
+        this.canvasViewModel = canvasViewModel;
+        this.dx = dx;
+        this.dy = dy;
+    }
+
+    @Override
+    public void execute() {
+        if (dx == 0 && dy == 0) return;
+        for (ShapeViewModel vm : canvasViewModel.getShapeViewModels()) {
+            if (vm.isSelected()) {
+                ShapeModel m = vm.getModel();
+                m.setX(m.getX() + dx);
+                m.setY(m.getY() + dy);
+            }
+        }
+        canvasViewModel.notifyListeners();
+    }
+
+    @Override
+    public void undo() {
+        if (dx == 0 && dy == 0) return;
+        for (ShapeViewModel vm : canvasViewModel.getShapeViewModels()) {
+            if (vm.isSelected()) {
+                ShapeModel m = vm.getModel();
+                m.setX(m.getX() - dx);
+                m.setY(m.getY() - dy);
+            }
+        }
+        canvasViewModel.notifyListeners();
+    }
+}

--- a/src/main/java/cose457/drawingtool/view/MainWindowView.java
+++ b/src/main/java/cose457/drawingtool/view/MainWindowView.java
@@ -52,6 +52,7 @@ public class MainWindowView {
 
     private double startX, startY;
     private double lastX, lastY;
+    private double totalDx, totalDy;
 
     private final CanvasState idleState = new IdleState();
     private final CanvasState drawingState = new DrawingState();
@@ -348,6 +349,8 @@ public class MainWindowView {
         public void onMousePressed(MouseEvent e) {
             lastX = e.getX();
             lastY = e.getY();
+            totalDx = 0;
+            totalDy = 0;
         }
 
         @Override
@@ -355,13 +358,17 @@ public class MainWindowView {
             double curX = e.getX(), curY = e.getY();
             double dx = curX - lastX;
             double dy = curY - lastY;
-            canvasViewModel.moveSelectedShapes(dx, dy);
+            canvasViewModel.translateSelectedShapes(dx, dy);
+            totalDx += dx;
+            totalDy += dy;
             lastX = curX;
             lastY = curY;
         }
 
         @Override
         public void onMouseReleased(MouseEvent e) {
+            canvasViewModel.translateSelectedShapes(-totalDx, -totalDy);
+            canvasViewModel.moveSelectedShapes(totalDx, totalDy);
             setState(idleState);
         }
     }

--- a/src/main/java/cose457/drawingtool/viewmodel/CanvasViewModel.java
+++ b/src/main/java/cose457/drawingtool/viewmodel/CanvasViewModel.java
@@ -4,6 +4,7 @@ import cose457.drawingtool.command.AddShapeCommand;
 import cose457.drawingtool.command.Command;
 import cose457.drawingtool.command.SelectShapeCommand;
 import cose457.drawingtool.command.MoveSelectedShapesCommand;
+import cose457.drawingtool.command.TranslateSelectedShapesCommand;
 import cose457.drawingtool.command.SelectShapesInAreaCommand;
 import cose457.drawingtool.command.ChangeZOrderCommand;
 import cose457.drawingtool.command.SetSelectedShapesBoundsCommand;
@@ -90,6 +91,15 @@ public class CanvasViewModel implements Observable<List<ShapeViewModel>> {
     public void moveSelectedShapes(double dx, double dy) {
         Command command = new MoveSelectedShapesCommand(this, dx, dy);
         executeCommand(command);
+    }
+
+    /**
+     * Move selected shapes directly without recording history.
+     * This is used for drag previews before the actual command is issued.
+     */
+    public void translateSelectedShapes(double dx, double dy) {
+        Command command = new TranslateSelectedShapesCommand(this, dx, dy);
+        command.execute();
     }
 
 


### PR DESCRIPTION
## Summary
- allow moving shapes in viewmodel without recording history
- track accumulated drag movement in the moving state
- on mouse release, revert temporary movement and issue a single move command
- create `TranslateSelectedShapesCommand` for temporary translations

## Testing
- `./mvnw -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684671e2c548832cb231e108067fb3bf